### PR TITLE
(main) Improves library structure and dox

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -37,7 +37,7 @@ cc_library(
 
 cc_library(
   name="core",
-  hdrs=["include/zen/core.hpp"],
+  hdrs=["include/zen/core.hpp"] + glob(["include/zen/core/*.hpp"]),
   strip_include_prefix="include",
   deps=[":fwd", ":meta", ":result"],
   visibility=["//visibility:public"]

--- a/Doxyfile
+++ b/Doxyfile
@@ -509,7 +509,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,

--- a/include/zen/core.hpp
+++ b/include/zen/core.hpp
@@ -4,133 +4,76 @@
 #include <utility>
 
 // Zen
-#include <zen/fwd.hpp>
-#include <zen/meta/first.hpp>
-#include <zen/result.hpp>
+#include <zen/core/all_dispatch.hpp>
+#include <zen/core/any_dispatch.hpp>
 
 namespace zen
 {
 
-template <typename... InvocableTs> class any_dispatch
-{
-public:
-  explicit constexpr any_dispatch(InvocableTs&&... fs) : invocables_{std::forward<InvocableTs>(fs)...}
-  {
-    static_assert(sizeof...(InvocableTs) > 0, "At least one invocable must be specified");
-  };
-
-  template <typename... ValueTs> decltype(auto) operator()(ValueTs&&... values) const
-  {
-    static constexpr std::size_t N = sizeof...(InvocableTs);
-    return call_exec_impl(std::make_index_sequence<N>{}, std::forward<ValueTs>(values)...);
-  }
-
-private:
-  template <typename... ValueTs, std::size_t... Is>
-  decltype(auto) exec_impl(std::index_sequence<Is...> _, ValueTs&&... values) const
-  {
-    using result_type = std::invoke_result_t<meta::first_t<InvocableTs...>, ValueTs...>;
-
-    static_assert(
-      (sizeof...(InvocableTs) == 1) ||
-        (std::is_same_v<result_type, std::invoke_result_t<InvocableTs, ValueTs...>> && ...),
-      "'InvocableTs' executed under [any_dispatch] must all have the same return type");
-
-    result_type return_value;
-    {
-      [[maybe_unused]] const auto unused =
-        ((return_value = std::get<Is>(this->invocables_)(std::forward<ValueTs>(values)...), return_value.valid()) ||
-         ...);
-    }
-    return return_value;
-  }
-
-  template <typename... ValueTs, typename Ignore, std::size_t... Is>
-  decltype(auto) exec_impl_ignore(std::index_sequence<Is...> _, Ignore&&, ValueTs&&... values) const
-  {
-    return exec_impl(_, std::forward<ValueTs>(values)...);
-  }
-
-  template <typename... ValueTs, std::size_t... Is>
-  decltype(auto) call_exec_impl(std::index_sequence<Is...> _, ValueTs&&... values) const
-  {
-    if constexpr (std::is_base_of_v<
-                    exec::executor_handle<std::remove_reference_t<meta::first_t<ValueTs...>>>,
-                    std::remove_reference_t<meta::first_t<ValueTs...>>>)
-    {
-      return exec_impl_ignore(_, std::forward<ValueTs>(values)...);
-    }
-    else
-    {
-      return exec_impl(_, std::forward<ValueTs>(values)...);
-    }
-  }
-
-  std::tuple<InvocableTs&&...> invocables_;
-};
-
-template <typename... InvocableTs> class all_dispatch
-{
-public:
-  explicit constexpr all_dispatch(InvocableTs&&... fs) : invocables_{std::forward<InvocableTs>(fs)...}
-  {
-    static_assert(sizeof...(InvocableTs) > 0, "At least one invocable must be specified");
-  };
-
-  template <typename... ValueTs> decltype(auto) operator()(ValueTs&&... values) const
-  {
-    static constexpr std::size_t N = sizeof...(InvocableTs);
-    return call_exec_impl(std::make_index_sequence<N>{}, std::forward<ValueTs>(values)...);
-  }
-
-private:
-  template <typename... ValueTs, std::size_t... Is>
-  decltype(auto) exec_impl(std::index_sequence<Is...> _, ValueTs&&... values) const
-  {
-    return create(
-      make_deferred_result(std::forward<InvocableTs>(std::get<Is>(invocables_)), std::forward_as_tuple(values...))...);
-  }
-
-  template <typename... ValueTs, typename Ignore, std::size_t... Is>
-  decltype(auto) exec_impl_ignore(std::index_sequence<Is...> _, Ignore&&, ValueTs&&... values) const
-  {
-    return exec_impl(_, std::forward<ValueTs>(values)...);
-  }
-
-  template <typename... ValueTs, std::size_t... Is>
-  decltype(auto) call_exec_impl(std::index_sequence<Is...> _, ValueTs&&... values) const
-  {
-    if constexpr (std::is_base_of_v<
-                    exec::executor_handle<std::remove_reference_t<meta::first_t<ValueTs...>>>,
-                    std::remove_reference_t<meta::first_t<ValueTs...>>>)
-    {
-      return exec_impl_ignore(_, std::forward<ValueTs>(values)...);
-    }
-    else
-    {
-      return exec_impl(_, std::forward<ValueTs>(values)...);
-    }
-  }
-
-  std::tuple<InvocableTs&&...> invocables_;
-};
-
+/**
+ * @brief Passes values as a <code>result</code>
+ */
 template <typename... ValueTs> constexpr decltype(auto) pass(ValueTs&&... values)
 {
-  static_assert(sizeof...(ValueTs) > 0, "at least one value must be specified");
   return make_result(std::forward<ValueTs>(values)...);
 }
 
+/**
+ * @brief Executes invocables until any of them returns an invalid result<T>, then terminates, returning a result<T>
+ * holding the first invalid status.
+ *
+ * Otherwise, returns a result<T> containing values returned by all invocables.
+@verbatim
+  auto r = pass(1, 2, 3)
+         | any(
+            [](int a, int b, int c) -> result<int> { return std::max({a, b, c}); },
+            [](int a, int b, int c) -> result<int> { return std::min({a, b, c}); },
+            [](int a, int b, int c) -> result<int> { return "failure"_msg; }
+          );
+
+  std::cout << std::boolalpha << static_cast<bool>(r) << std::endl;  // true
+@endverbatim
+ */
 template <typename... InvocableTs> constexpr decltype(auto) any(InvocableTs&&... t)
 {
   return any_dispatch<std::remove_reference_t<InvocableTs>...>{std::forward<InvocableTs>(t)...};
 }
 
+/**
+ * @brief Executes invocables until any of them returns a valid result<T>, then terminates, returning that result<T>.
+ *
+ * Otherwise, returns result<T> with the last invalid status.
+@verbatim
+  auto r = pass(1, 2, 3)
+         | all(
+            [](int a, int b, int c) -> result<int> { return std::max({a, b, c}); },
+            [](int a, int b, int c) -> result<int> { return std::min({a, b, c}); },
+            [](int a, int b, int c) -> result<int> { return "failure"_msg; }
+          );
+
+  std::cout << std::boolalpha << static_cast<bool>(r) << std::endl;  // false
+@endverbatim
+ */
 template <typename... InvocableTs> constexpr decltype(auto) all(InvocableTs&&... t)
 {
   return all_dispatch<std::remove_reference_t<InvocableTs>...>{std::forward<InvocableTs>(t)...};
 }
 
+/**
+ * @brief Chains together invocables which return a <code>result<T></code>
+ *
+ * Short-circuits when an invalid <code>result<T></code> is produce, and returns a <code>result<T></code>
+ * with the invalid status causing failure.
+ *
+@verbatim
+  auto r = pass(1, 2, 3)
+         | [](int a, int b, int c) -> result<int> { return std::max({a, b, c}); }, // <-- executed
+         | [](int a, int b, int c) -> result<int> { return "failure"_msg; }        // <-- execution stops here
+           [](int a, int b, int c) -> result<int> { return std::min({a, b, c}); }; // <-- never invoked
+
+  std::cout << std::boolalpha << static_cast<bool>(r) << std::endl;  // false
+@endverbatim
+ */
 template <typename T, typename Fn> decltype(auto) operator|(result<T>&& r, Fn&& f)
 {
   using original_return_type = decltype(std::apply(std::forward<Fn>(f), as_tuple(r)));

--- a/include/zen/core/all_dispatch.hpp
+++ b/include/zen/core/all_dispatch.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+// C++ Standard Library
+#include <tuple>
+#include <utility>
+
+// Zen
+#include <zen/fwd.hpp>
+#include <zen/meta/first.hpp>
+#include <zen/result.hpp>
+
+namespace zen
+{
+
+/**
+ * @brief Implements invocable dispatch behavior for free-function <code>all</code>
+ *
+ * Executes invocables until any of them returns an invalid result, then terminates, returning a result
+ * holding the first invalid status. Otherwise, returns a result containing values returned by all invocables.
+ * \n
+ * This is the default, single threaded implementation. Specializations of all_dispatch may be made
+ * available for invocation in different execution contexts, such as multi-threaded dispatch.
+ */
+template <typename... InvocableTs> class all_dispatch
+{
+public:
+  explicit constexpr all_dispatch(InvocableTs&&... fs) : invocables_{std::forward<InvocableTs>(fs)...}
+  {
+    static_assert(sizeof...(InvocableTs) > 0, "At least one invocable must be specified");
+  };
+
+  /**
+   * @brief Invokes all held invocables with <code>values</code> as arguments
+   *
+   * @return result
+   */
+  template <typename... ValueTs> decltype(auto) operator()(ValueTs&&... values) const
+  {
+    static constexpr std::size_t N = sizeof...(InvocableTs);
+    return call_exec_impl(std::make_index_sequence<N>{}, std::forward<ValueTs>(values)...);
+  }
+
+private:
+  template <typename... ValueTs, std::size_t... Is>
+  decltype(auto) exec_impl(std::index_sequence<Is...> _, ValueTs&&... values) const
+  {
+    return create(
+      make_deferred_result(std::forward<InvocableTs>(std::get<Is>(invocables_)), std::forward_as_tuple(values...))...);
+  }
+
+  template <typename... ValueTs, typename Ignore, std::size_t... Is>
+  decltype(auto) exec_impl_ignore(std::index_sequence<Is...> _, Ignore&&, ValueTs&&... values) const
+  {
+    return exec_impl(_, std::forward<ValueTs>(values)...);
+  }
+
+  template <typename... ValueTs, std::size_t... Is>
+  decltype(auto) call_exec_impl(std::index_sequence<Is...> _, ValueTs&&... values) const
+  {
+    if constexpr (std::is_base_of_v<
+                    exec::executor_handle<std::remove_reference_t<meta::first_t<ValueTs...>>>,
+                    std::remove_reference_t<meta::first_t<ValueTs...>>>)
+    {
+      return exec_impl_ignore(_, std::forward<ValueTs>(values)...);
+    }
+    else
+    {
+      return exec_impl(_, std::forward<ValueTs>(values)...);
+    }
+  }
+
+  std::tuple<InvocableTs&&...> invocables_;
+};
+
+}  // namespace zen

--- a/include/zen/core/any_dispatch.hpp
+++ b/include/zen/core/any_dispatch.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+// C++ Standard Library
+#include <tuple>
+#include <utility>
+
+// Zen
+#include <zen/fwd.hpp>
+#include <zen/meta/first.hpp>
+#include <zen/result.hpp>
+
+namespace zen
+{
+
+/**
+ * @brief Implements invocable dispatch behavior for free-function <code>any</code>
+ *
+ * Executes invocables until any of them returns a valid result, then terminates, returning that result.
+ * Otherwise, returns result with the last invalid status.
+ * \n
+ * This is the default, single threaded implementation. Specializations of any_dispatch may be made
+ * available for invocation in different execution contexts, such as multi-threaded dispatch.
+ */
+template <typename... InvocableTs> class any_dispatch
+{
+public:
+  explicit constexpr any_dispatch(InvocableTs&&... fs) : invocables_{std::forward<InvocableTs>(fs)...}
+  {
+    static_assert(sizeof...(InvocableTs) > 0, "At least one invocable must be specified");
+  };
+
+  /**
+   * @brief Invokes all held invocables with <code>values</code> as arguments
+   *
+   * @return result
+   */
+  template <typename... ValueTs> decltype(auto) operator()(ValueTs&&... values) const
+  {
+    static constexpr std::size_t N = sizeof...(InvocableTs);
+    return call_exec_impl(std::make_index_sequence<N>{}, std::forward<ValueTs>(values)...);
+  }
+
+private:
+  template <typename... ValueTs, std::size_t... Is>
+  decltype(auto) exec_impl(std::index_sequence<Is...> _, ValueTs&&... values) const
+  {
+    using result_type = std::invoke_result_t<meta::first_t<InvocableTs...>, ValueTs...>;
+
+    static_assert(
+      (sizeof...(InvocableTs) == 1) ||
+        (std::is_same_v<result_type, std::invoke_result_t<InvocableTs, ValueTs...>> && ...),
+      "'InvocableTs' executed under [any_dispatch] must all have the same return type");
+
+    result_type return_value;
+    {
+      [[maybe_unused]] const auto unused =
+        ((return_value = std::get<Is>(this->invocables_)(std::forward<ValueTs>(values)...), return_value.valid()) ||
+         ...);
+    }
+    return return_value;
+  }
+
+  template <typename... ValueTs, typename Ignore, std::size_t... Is>
+  decltype(auto) exec_impl_ignore(std::index_sequence<Is...> _, Ignore&&, ValueTs&&... values) const
+  {
+    return exec_impl(_, std::forward<ValueTs>(values)...);
+  }
+
+  template <typename... ValueTs, std::size_t... Is>
+  decltype(auto) call_exec_impl(std::index_sequence<Is...> _, ValueTs&&... values) const
+  {
+    if constexpr (std::is_base_of_v<
+                    exec::executor_handle<std::remove_reference_t<meta::first_t<ValueTs...>>>,
+                    std::remove_reference_t<meta::first_t<ValueTs...>>>)
+    {
+      return exec_impl_ignore(_, std::forward<ValueTs>(values)...);
+    }
+    else
+    {
+      return exec_impl(_, std::forward<ValueTs>(values)...);
+    }
+  }
+
+  std::tuple<InvocableTs&&...> invocables_;
+};
+
+}  // namespace zen

--- a/include/zen/fwd.hpp
+++ b/include/zen/fwd.hpp
@@ -7,9 +7,7 @@ namespace zen
 {
 
 template <typename T> class result;
-
 template <typename... Ts> class any_dispatch;
-
 template <typename... Ts> class all_dispatch;
 
 }  // namespace zen

--- a/include/zen/result.hpp
+++ b/include/zen/result.hpp
@@ -1,184 +1,226 @@
 #pragma once
 
 // C++ Standard Library
+#include <exception>
 #include <iosfwd>
 #include <utility>
 
 // Zen
 #include <zen/fwd.hpp>
-#include <zen/meta/invocable.hpp>
 #include <zen/meta/is_specialization.hpp>
-#include <zen/meta/transform.hpp>
+#include <zen/meta/type_to_string.hpp>
+#include <zen/result/deferred_result.hpp>
 #include <zen/result/status.hpp>
+#include <zen/result/to_result.hpp>
 #include <zen/utility/value_mem.hpp>
 
 namespace zen
 {
-template <typename T> struct to_result
-{
-  using type = result<T>;
-};
 
-template <typename T> struct to_result<result<T>>
-{
-  using type = result<T>;
-};
-
-template <typename T> using to_result_t = typename to_result<T>::type;
-
-template <typename InvocableT, typename ArgumentTupleT> class deferred_result
+/**
+ * @brief Exception thrown when result does not contain a valid value
+ */
+class bad_result_access final : std::exception
 {
 public:
-  using invocable_return_type = meta::result_of_apply_t<InvocableT, ArgumentTupleT>;
-  using return_type = to_result_t<invocable_return_type>;
-  constexpr deferred_result(InvocableT&& fn, ArgumentTupleT&& args) :
-      fn_{std::forward<InvocableT>(fn)}, args_{std::forward<ArgumentTupleT>(args)}
-  {}
-
-  [[nodiscard]] constexpr auto operator()() const -> return_type { return std::apply(fn_, args_); }
+  explicit bad_result_access(const char* const type_info) : type_info_{type_info} {}
 
 private:
-  InvocableT&& fn_;
-  ArgumentTupleT&& args_;
+  const char* what() const noexcept override { return type_info_; }
+  const char* type_info_;
 };
 
-
-template <typename InvocableT> class deferred_result<InvocableT, void>
-{
-public:
-  using invocable_return_type = meta::result_of_apply_t<InvocableT, std::tuple<>>;
-  using return_type = to_result_t<invocable_return_type>;
-  constexpr deferred_result(InvocableT&& fn) : fn_{std::forward<InvocableT>(fn)} {}
-
-  [[nodiscard]] constexpr auto operator()() const -> return_type { return fn_(); }
-
-private:
-  InvocableT&& fn_;
-};
-
-template <typename D> struct deferred_result_of;
-
-template <typename InvocableT, typename InputT> struct deferred_result_of<deferred_result<InvocableT, InputT>>
-{
-  using type = typename deferred_result<InvocableT, InputT>::return_type;
-};
-
-template <typename D> using deferred_result_of_t = typename deferred_result_of<D>::type;
-
-template <typename InvocableT> decltype(auto) make_deferred_result(InvocableT&& invocable)
-{
-  return deferred_result<std::remove_reference_t<InvocableT>, void>{std::forward<InvocableT>(invocable)};
-}
-
-template <typename InvocableT, typename ArgTupleT>
-decltype(auto) make_deferred_result(InvocableT&& invocable, ArgTupleT&& arg)
-{
-  return deferred_result<std::remove_reference_t<InvocableT>, std::remove_reference_t<ArgTupleT>>{
-    std::forward<InvocableT>(invocable), std::forward<ArgTupleT>(arg)};
-}
-
+/**
+ * @brief Stores a value type, or an error message
+ *
+ * @tparam T  value type
+ */
 template <typename T> class result final : private value_mem<T>
 {
 public:
+  /**
+   * @brief Creates an invalid result from an error message
+   *
+   * @param error_message  error description message; must not be <code>zen::Valid</code>
+   */
+  template <char... Elements> constexpr result(message<Elements...>&& error_message);
+
+  /**
+   * @brief Creates an invalid result from an error status
+   *
+   * @param status  error status
+   */
+  constexpr result(result_status&& status);
+
+  /**
+   * @brief Creates a valid result from a value
+   *
+   * @param value  value payload
+   */
+  constexpr result(const T& value);
+
+  /**
+   * @copydoc result(const T&)
+   */
+  constexpr result(T&& value);
+
+  /**
+   * @brief Default initializes result to invalid (Unknown) state
+   */
   constexpr result() = default;
 
-  template <char... Elements>
-  constexpr result(message<Elements...> error_message) : value_mem<T>{}, status_{error_message}
-  {
-    static_assert(
-      !are_messages_equal<message<Elements...>, decltype(Valid)>(),
-      "To set a valid result, assign a value, not an error message");
-  }
+  /**
+   * @brief Destroys result value, if <code>valid() == true</code>
+   */
+  ~result();
 
-  constexpr result(result_status&& status) : value_mem<T>{}, status_{std::move(status)} {}
-  constexpr result(const T& value) : value_mem<T>{value}, status_{Valid} {}
-  constexpr result(T&& value) : value_mem<T>{std::move(value)}, status_{Valid} {}
+  /**
+   * @brief Returns immutable reference to result value
+   *
+   * @note use operator* as a more efficient option that does not check validity
+   *
+   * @throws bad_result_access  if result is not valid
+   */
+  [[nodiscard]] const T& value() const&;
 
-  ~result()
-  {
-    if (status_.valid())
-    {
-      result::destroy();
-    }
-  }
+  /**
+   * @brief Returns rvalue reference to result value
+   *
+   * @note use operator* as a more efficient option that does not check validity
+   *
+   * @throws bad_result_access  if result is not valid
+   */
+  [[nodiscard]] T&& value() &&;
 
-  using value_mem<T>::value;
+  /**
+   * @brief Returns status associated with result
+   */
+  [[nodiscard]] constexpr result_status status() const;
+
+  /**
+   * @brief Returns <code>true</code> if result value pay load is valid
+   *
+   * If <code>valid() == true</code>, then <code>status().message() == Valid</code>
+   */
+  [[nodiscard]] constexpr bool valid() const;
+
+  /**
+   * @copydoc valid
+   *
+   * Enables implicit cast to <code>bool</code> based on valid()
+   */
+  [[nodiscard]] constexpr operator bool() const;
+
   using value_mem<T>::operator*;
   using value_mem<T>::operator->;
-
-  [[nodiscard]] constexpr result_status status() const { return status_; }
-
-  [[nodiscard]] constexpr bool valid() const { return status_.valid(); }
-
-  [[nodiscard]] constexpr operator bool() const { return status_.valid(); }
 
 private:
   result_status status_;
 };
 
+template <typename T>
+template <char... Elements>
+constexpr result<T>::result(message<Elements...>&& error_message) : value_mem<T>{}, status_{error_message}
+{
+  static_assert(
+    !are_messages_equal<message<Elements...>, decltype(Valid)>(),
+    "To set a valid result, assign a value, not an error message");
+}
+
+template <typename T> constexpr result<T>::result(result_status&& status) : value_mem<T>{}, status_{std::move(status)}
+{}
+
+template <typename T> constexpr result<T>::result(const T& value) : value_mem<T>{value}, status_{Valid} {}
+
+template <typename T> constexpr result<T>::result(T&& value) : value_mem<T>{std::move(value)}, status_{Valid} {}
+
+template <typename T> result<T>::~result()
+{
+  if (status_.valid())
+  {
+    result::destroy();
+  }
+}
+
+template <typename T> const T& result<T>::value() const&
+{
+  if (!status_.valid())
+  {
+    throw bad_result_access{meta::type_to_string<T>()};
+  }
+  return **this;
+}
+
+template <typename T> T&& result<T>::value() &&
+{
+  if (!status_.valid())
+  {
+    throw bad_result_access{meta::type_to_string<T>()};
+  }
+  status_ = Unknown;
+  return std::move(**this);
+}
+
+template <typename T> constexpr result_status result<T>::status() const { return status_; }
+
+template <typename T> constexpr bool result<T>::valid() const { return status_.valid(); }
+
+template <typename T> constexpr result<T>::operator bool() const { return status_.valid(); }
+
 template <typename T> [[nodiscard]] constexpr decltype(auto) as_tuple(const result<T>& r)
 {
-  return std::forward_as_tuple(r.value());
+  return std::forward_as_tuple(*r);
 }
 
 template <typename... Ts> [[nodiscard]] constexpr decltype(auto) as_tuple(const result<std::tuple<Ts...>>& r)
 {
-  return r.value();
+  return *r;
 }
 
-template <typename DeferredT> decltype(auto) create(DeferredT deferred_result) { return deferred_result(); }
-
-template <typename ResultTupleT, typename DeferredTupleT, std::size_t... Is>
-decltype(auto) create(ResultTupleT&& result_tuple, DeferredTupleT&& deferred_result_tuple, std::index_sequence<Is...> _)
+template <typename T> [[nodiscard]] constexpr decltype(auto) as_tuple(result<T>&& r)
 {
-  using concat_result_tuple_type =
-    decltype(std::tuple_cat(as_tuple(std::get<Is>(std::forward<ResultTupleT>(result_tuple)))...));
-  using result_type = result<meta::transform_t<concat_result_tuple_type, std::remove_reference>>;
-
-  result_type r;
-  if (((std::get<Is>(std::forward<ResultTupleT>(result_tuple)) =
-          std::get<Is>(std::forward<DeferredTupleT>(deferred_result_tuple))(),
-        std::get<Is>(std::forward<ResultTupleT>(result_tuple)).valid()) &&
-       ...))
-  {
-    r = result_type{std::tuple_cat(as_tuple(std::get<Is>(std::forward<ResultTupleT>(result_tuple)))...)};
-  }
-  else
-  {
-    [[maybe_unused]] const auto _ =
-      ((std::get<Is>(std::forward<ResultTupleT>(result_tuple)).valid() ||
-        (r = result_type{std::get<Is>(std::forward<ResultTupleT>(result_tuple)).status()}, false)) &&
-       ...);
-  }
-  return r;
+  return std::forward_as_tuple(*r);
 }
 
-template <typename DeferredT1, typename DeferredT2, typename... OtherDeferredTs>
-decltype(auto) create(DeferredT1 d1, DeferredT2 d2, OtherDeferredTs... dn)
-{
-  std::
-    tuple<deferred_result_of_t<DeferredT1>, deferred_result_of_t<DeferredT2>, deferred_result_of_t<OtherDeferredTs>...>
-      results;
-  return create(
-    results, std::forward_as_tuple(d1, d2, dn...), std::make_index_sequence<sizeof...(OtherDeferredTs) + 2>{});
-}
+template <typename... Ts> [[nodiscard]] constexpr decltype(auto) as_tuple(result<std::tuple<Ts...>>&& r) { return *r; }
 
+/**
+ * @brief Traits type which isolates the type returned by <code>result::value()</code> as a <code>std::tuple</code>
+ */
 template <typename ResultT> struct result_as_tuple;
 
+/**
+ * @copydoc result_as_tuple
+ */
 template <typename T> struct result_as_tuple<result<T>>
 {
   using type = std::tuple<T>;
 };
 
+/**
+ * @copydoc result_as_tuple
+ */
 template <typename... Ts> struct result_as_tuple<result<std::tuple<Ts...>>>
 {
   using type = std::tuple<Ts...>;
 };
 
+/**
+ * @copydoc result_as_tuple
+ */
 template <typename ResultT> using result_as_tuple_t = typename result_as_tuple<ResultT>::type;
 
+/**
+ * @brief Wraps values or result_status in a result
+ *
+ * @param values...  values to wrap, or result_status
+ *
+ * @return result<Ts...>
+ */
 template <typename... Ts> decltype(auto) make_result(Ts&&... values)
 {
+  static_assert(sizeof...(Ts) > 0, "at least one value must be specified");
+
   if constexpr (sizeof...(Ts) > 1)
   {
     return result<std::tuple<std::remove_reference_t<Ts>...>>{{std::forward<Ts>(values)...}};
@@ -193,11 +235,23 @@ template <typename... Ts> decltype(auto) make_result(Ts&&... values)
   }
 }
 
+/**
+ * @brief <code>std::ostream</code> overload for <code>result<T></code>
+ *
+ * Puts <code>r</code> into <code>os</code> if valid, otherwise puts <code>r.status</code>
+ *
+ * @tparam T  value type
+ *
+ * @param[in,out] os  output stream
+ * @param r  result
+ *
+ * @return os
+ */
 template <typename T> inline std::ostream& operator<<(std::ostream& os, const result<T>& r)
 {
   if (r.valid())
   {
-    return os << r.value();
+    return os << *r;
   }
   return os << r.status();
 }

--- a/include/zen/result/deferred_result.hpp
+++ b/include/zen/result/deferred_result.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+// C++ Standard Library
+#include <utility>
+
+// Zen
+#include <zen/fwd.hpp>
+#include <zen/meta/invocable.hpp>
+#include <zen/meta/transform.hpp>
+#include <zen/result/to_result.hpp>
+
+namespace zen
+{
+#define DOXYGEN_SHOULD_SKIP_THIS 1
+#ifdef DOXYGEN_SHOULD_SKIP_THIS
+namespace detail
+{
+
+template <typename ResultTupleT, typename DeferredTupleT, std::size_t... Is>
+decltype(auto) create(ResultTupleT&& result_tuple, DeferredTupleT&& deferred_result_tuple, std::index_sequence<Is...> _)
+{
+  using concat_result_tuple_type =
+    decltype(std::tuple_cat(as_tuple(std::get<Is>(std::forward<ResultTupleT>(result_tuple)))...));
+  using result_type = result<meta::transform_t<concat_result_tuple_type, std::remove_reference>>;
+
+  result_type r;
+  if (((std::get<Is>(std::forward<ResultTupleT>(result_tuple)) =
+          std::get<Is>(std::forward<DeferredTupleT>(deferred_result_tuple))(),
+        std::get<Is>(std::forward<ResultTupleT>(result_tuple)).valid()) &&
+       ...))
+  {
+    r = result_type{std::tuple_cat(as_tuple(std::get<Is>(std::forward<ResultTupleT>(result_tuple)))...)};
+  }
+  else
+  {
+    [[maybe_unused]] const auto _ =
+      ((std::get<Is>(std::forward<ResultTupleT>(result_tuple)).valid() ||
+        (r = result_type{std::get<Is>(std::forward<ResultTupleT>(result_tuple)).status()}, false)) &&
+       ...);
+  }
+  return r;
+}
+
+}  // namespace detail
+#endif  // DOXYGEN_SHOULD_SKIP_THIS
+
+/**
+ * @brief An invocable packaged with its arguments, which returns a result
+ */
+template <typename InvocableT, typename ArgumentTupleT> class deferred_result
+{
+public:
+  using invocable_return_type = meta::result_of_apply_t<InvocableT, ArgumentTupleT>;
+  using return_type = to_result_t<invocable_return_type>;
+
+  constexpr deferred_result(InvocableT&& fn, ArgumentTupleT&& args) :
+      fn_{std::forward<InvocableT>(fn)}, args_{std::forward<ArgumentTupleT>(args)}
+  {}
+
+  [[nodiscard]] constexpr auto operator()() const -> return_type { return std::apply(fn_, args_); }
+
+private:
+  InvocableT&& fn_;
+  ArgumentTupleT&& args_;
+};
+
+/**
+ * @brief An invocable with no arguments, which returns a result
+ */
+template <typename InvocableT> class deferred_result<InvocableT, void>
+{
+public:
+  using invocable_return_type = meta::result_of_apply_t<InvocableT, std::tuple<>>;
+  using return_type = to_result_t<invocable_return_type>;
+  constexpr deferred_result(InvocableT&& fn) : fn_{std::forward<InvocableT>(fn)} {}
+
+  [[nodiscard]] constexpr auto operator()() const -> return_type { return fn_(); }
+
+private:
+  InvocableT&& fn_;
+};
+
+/**
+ * @brief Traits type which isolates the type returned by <code>deferred_result::operator()</code>
+ */
+template <typename D> struct deferred_result_of;
+
+/**
+ * @copydoc deferred_result_of
+ */
+template <typename InvocableT, typename InputT> struct deferred_result_of<deferred_result<InvocableT, InputT>>
+{
+  using type = typename deferred_result<InvocableT, InputT>::return_type;
+};
+
+/**
+ * @copydoc deferred_result_of
+ */
+template <typename D> using deferred_result_of_t = typename deferred_result_of<std::remove_reference_t<D>>::type;
+
+/**
+ * @brief Creates a deferred_result with no arguments
+ */
+template <typename InvocableT> decltype(auto) make_deferred_result(InvocableT&& invocable)
+{
+  return deferred_result<std::remove_reference_t<InvocableT>, void>{std::forward<InvocableT>(invocable)};
+}
+
+/**
+ * @brief Creates a deferred_result with a <code>std::tuple</code> of arguments
+ */
+template <typename InvocableT, typename ArgTupleT>
+decltype(auto) make_deferred_result(InvocableT&& invocable, ArgTupleT&& arg)
+{
+  return deferred_result<std::remove_reference_t<InvocableT>, std::remove_reference_t<ArgTupleT>>{
+    std::forward<InvocableT>(invocable), std::forward<ArgTupleT>(arg)};
+}
+
+/**
+ * @brief Creates a result from a single deferred invocable
+ *
+ * @param dr  invocable which return a result
+ */
+template <typename DeferredT> decltype(auto) create(DeferredT&& dr) { return dr(); }
+
+/**
+ * @brief Creates a result from two or more deferred invocables
+ *
+ * Short-circuits when an invalid result is returned by <code>d1 ... dn</code>
+ *
+ * @param d1  first invocable
+ * @param d2  second invocable
+ * @param dn...  other invocables
+ */
+template <typename DeferredT1, typename DeferredT2, typename... OtherDeferredTs>
+decltype(auto) create(DeferredT1&& d1, DeferredT2&& d2, OtherDeferredTs&&... dn)
+{
+  std::
+    tuple<deferred_result_of_t<DeferredT1>, deferred_result_of_t<DeferredT2>, deferred_result_of_t<OtherDeferredTs>...>
+      results;
+  return detail::create(
+    results,
+    std::forward_as_tuple(
+      std::forward<DeferredT1>(d1), std::forward<DeferredT2>(d2), std::forward<OtherDeferredTs>(dn)...),
+    std::make_index_sequence<sizeof...(OtherDeferredTs) + 2>{});
+}
+
+}  // namespace zen

--- a/include/zen/result/to_result.hpp
+++ b/include/zen/result/to_result.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+// Zen
+#include <zen/fwd.hpp>
+
+namespace zen
+{
+
+/**
+ * @brief Converts a type \c T to a corresponding result<T>
+ */
+template <typename T> struct to_result
+{
+  using type = result<T>;
+};
+
+/**
+ * @copydoc to_result
+ */
+template <typename T> struct to_result<result<T>>
+{
+  using type = result<T>;
+};
+
+/**
+ * @copydoc to_result
+ */
+template <typename T> using to_result_t = typename to_result<T>::type;
+
+}  // namespace zen

--- a/include/zen/utility/value_mem.hpp
+++ b/include/zen/utility/value_mem.hpp
@@ -32,28 +32,28 @@ protected:
    *
    * @warning behavior undefined if <code>emplace</code> has not been called
    */
-  [[nodiscard]] constexpr T& value() { return (*data()); }
+  [[nodiscard]] constexpr T& operator*() & { return (*data()); }
 
   /**
    * @brief Returns immutable reference to held value <code>T</code>
    *
    * @warning behavior undefined if <code>emplace</code> has not been called
    */
-  [[nodiscard]] constexpr const T& value() const { return (*data()); }
+  [[nodiscard]] constexpr const T& operator*() const& { return (*data()); }
 
   /**
    * @brief Returns reference to held value <code>T</code>
    *
    * @warning behavior undefined if <code>emplace</code> has not been called
    */
-  [[nodiscard]] constexpr T& operator*() { return (*data()); }
+  [[nodiscard]] constexpr T&& operator*() && { return (*data()); }
 
   /**
    * @brief Returns immutable reference to held value <code>T</code>
    *
    * @warning behavior undefined if <code>emplace</code> has not been called
    */
-  [[nodiscard]] constexpr const T& operator*() const { return (*data()); }
+  [[nodiscard]] constexpr const T&& operator*() const&& { return (*data()); }
 
   /**
    * @brief Returns pointer to held value <code>T</code>

--- a/test/result.cpp
+++ b/test/result.cpp
@@ -1,3 +1,6 @@
+// C++ Standard Library
+#include <vector>
+
 // GTest
 #include <gtest/gtest.h>
 
@@ -12,6 +15,25 @@ TEST(Result, Default)
   ASSERT_FALSE(r.valid()) << r;
   EXPECT_EQ(r.status(), Unknown);
 }
+
+TEST(Result, DefaultBadAccess)
+{
+  result<int> r;
+  [[maybe_unused]] int v = 0;
+  ASSERT_THROW(v = r.value(), bad_result_access);
+}
+
+TEST(Result, MoveResultValue)
+{
+  result<std::vector<int>> r = std::vector<int>{1, 2, 3, 4};
+
+  auto value = std::move(r).value();
+
+  ASSERT_FALSE(r.valid());
+
+  EXPECT_EQ(value, (std::vector<int>{1, 2, 3, 4}));
+}
+
 
 TEST(Result, CreateValidFromDeferredNoArg)
 {


### PR DESCRIPTION
- Re-arranges `result` components
- Adds `bad_result_value` exception and changes the behavior of `result::value()` to throw on invalid
- Adds `&&` versions for `value()`
- Adds dox for many things